### PR TITLE
Require rspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: .
   specs:
-    rspec-junklet (2.0.0)
+    rspec-junklet (2.1.2)
+      rspec (>= 2.0, < 4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/rspec/junklet.rb
+++ b/lib/rspec/junklet.rb
@@ -1,3 +1,4 @@
+require 'rspec'
 require_relative "./junklet/version"
 require_relative "./junklet/junk"
 require_relative "./junklet/junklet"

--- a/rspec-junklet.gemspec
+++ b/rspec-junklet.gemspec
@@ -22,4 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 2.0"
   spec.add_development_dependency "pry", "~> 0.10"
+
+  spec.add_runtime_dependency "rspec", [">= 2.0", "< 4.0"]
 end


### PR DESCRIPTION
`rspec` was not explicitly loaded in the gem. This PR fixes that. It should also resolve: https://github.com/dbrady/rspec-junklet/issues/2. I came across the same error when running a rake task. 
